### PR TITLE
removing cookie from vary response header

### DIFF
--- a/vcl_snippets/fetch.vcl
+++ b/vcl_snippets/fetch.vcl
@@ -26,3 +26,9 @@
     set beresp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
     unset beresp.http.Fastly-Drupal-HTML;
   }
+
+  # Drupal can respond with Vary on Cookie, which is bad for CHR. 
+  # Remove cookie from the Vary header, as we handle request cookies already in vcl_recv. 
+  if ( beresp.http.Vary:cookie ) {
+    unset beresp.http.Vary:cookie;
+  }


### PR DESCRIPTION
This PR aims to remove the inclusion of `cookie` in the Vary response header that Drupal replies with on their html responses. 

One thought that comes to mind is if we need to enable a way for folks to conditionally disable this, without explicitly removing it from the snippet. I can't think of a specific reason to do so, but maybe if users were trying to set up some kind of A/B testing with cookies they would need the option to vary on cookie. 

If it's not seen as a big issue, however, I would vote to have it merged and addressed in the future if someone presents the idea. 