### PR TITLE
The \Symfony\Component\HttpKernel\Event\ResponseEvent::isMasterReques…

### DIFF
--- a/src/EventSubscriber/AddStaleHeaders.php
+++ b/src/EventSubscriber/AddStaleHeaders.php
@@ -53,7 +53,7 @@ class AddStaleHeaders implements EventSubscriberInterface {
     $config = $this->config->get('fastly.settings');
 
     // Only modify the master request.
-    if ((!$event->isMasterRequest())) {
+    if ((!$event->isMainRequest())) {
       return;
     }
 

--- a/src/EventSubscriber/SurrogateKeyGenerator.php
+++ b/src/EventSubscriber/SurrogateKeyGenerator.php
@@ -50,7 +50,7 @@ class SurrogateKeyGenerator implements EventSubscriberInterface {
    *   The event to process.
    */
   public function onRespond(ResponseEvent $event) {
-    if (!$event->isMasterRequest()) {
+    if (!$event->isMainRequest()) {
       return;
     }
 


### PR DESCRIPTION
…t() no longer exists in D10.